### PR TITLE
Allow followups to define the skipped days

### DIFF
--- a/share/holidays.xsd
+++ b/share/holidays.xsd
@@ -26,6 +26,9 @@
             <xs:enumeration value="saturday"/>
         </xs:restriction>
     </xs:simpleType>
+    <xs:simpleType name="daynamelist">
+        <xs:list itemType="daynames" />
+    </xs:simpleType>
     <xs:simpleType name="calendars">
         <xs:restriction base="xs:string">
             <xs:enumeration value="buddhist"/>
@@ -57,6 +60,7 @@
         <xs:attribute name="day" type="dayInt" use="required"/>
         <xs:attribute name="month" type="monthInt" use="required"/>
         <xs:attribute name="followup" type="daynames" use="required" />
+        <xs:attribute name="replaced" type="daynamelist" use="optional" />
         <xs:attribute name="free" type="xs:boolean" use="required"/>
         <xs:attribute name="comment" type="xs:string"/>
         <xs:attribute name="calendar" type="calendars"/>

--- a/src/HolidayIteratorFactory.php
+++ b/src/HolidayIteratorFactory.php
@@ -34,6 +34,7 @@ use Org_Heigl\Holidaychecker\IteratorItem\DateFollowUp;
 use Org_Heigl\Holidaychecker\IteratorItem\Easter;
 use Org_Heigl\Holidaychecker\IteratorItem\EasterOrthodox;
 use Org_Heigl\Holidaychecker\IteratorItem\Relative;
+use function explode;
 
 class HolidayIteratorFactory
 {
@@ -131,7 +132,8 @@ class HolidayIteratorFactory
                     $child->textContent,
                     $this->getFree($child),
                     $day,
-                    $child->getAttribute('followup')
+                    $child->getAttribute('followup'),
+                    ($child->hasAttribute('replaced')?explode(' ', $child->getAttribute('replaced')):[])
                 );
             case 'relative':
                 return new Relative(

--- a/tests/IteratorItem/DateFollowUpTest.php
+++ b/tests/IteratorItem/DateFollowUpTest.php
@@ -44,11 +44,19 @@ class DateFollowUpTest extends TestCase
      * @covers \Org_Heigl\Holidaychecker\IteratorItem\DateFollowUp::__construct
      * @covers \Org_Heigl\Holidaychecker\IteratorItem\DateFollowUp::dateMatches
      */
-    public function testThatDateFollowupTestWorks($dateTime, $day, $month, $followup, $result, $name, $isHoliday)
-    {
+    public function testThatDateFollowupTestWorks(
+        $dateTime,
+        $day,
+        $month,
+        $followup,
+        $replaced,
+        $result,
+        $name,
+        $isHoliday
+    ) {
         $calendarDate = CalendarDayFactory::createCalendarDay($day, $month, Calendar::GREGORIAN);
 
-        $followUp = new DateFollowUp($name, $isHoliday, $calendarDate, $followup);
+        $followUp = new DateFollowUp($name, $isHoliday, $calendarDate, $followup, $replaced);
         $this->assertEquals($result, $followUp->dateMatches($dateTime));
         $this->assertEquals($name, $followUp->getName());
         $this->assertEquals($isHoliday, $followUp->isHoliday());
@@ -57,8 +65,37 @@ class DateFollowUpTest extends TestCase
     public function dateProvider()
     {
         return [
-            [new \DateTimeImmutable('2018-03-01 12:00:00+00:00'), 25, 2, 'thursday', true, 'test', true],
-            [new \DateTimeImmutable('2018-02-26 12:00:00+00:00'), 24, 2, 'monday', true, 'test', true],
+            [new \DateTimeImmutable('2018-03-01 12:00:00+00:00'), 25, 2, 'thursday', [], true, 'test', true],
+            [new \DateTimeImmutable('2018-02-26 12:00:00+00:00'), 24, 2, 'monday', [], true, 'test', true],
+   //         [new \DateTimeImmutable('2019-01-01 12:00:00+00:00'), 30, 12, 'tuesday', [], true, 'test', true],
+            [
+                new \DateTimeImmutable('2019-10-12 12:00:00+00:00'),
+                11,
+                10,
+                'saturday',
+                ['thursday', 'friday'],
+                true,
+                'test',
+                true
+            ], [
+                new \DateTimeImmutable('2019-10-12 12:00:00+00:00'),
+                10,
+                10,
+                'saturday',
+                ['thursday', 'friday'],
+                true,
+                'test',
+                true
+            ], [
+                new \DateTimeImmutable('2019-10-09 12:00:00+00:00'),
+                9,
+                10,
+                'saturday',
+                ['thursday', 'friday'],
+                true,
+                'test',
+                true
+            ],
         ];
     }
 }


### PR DESCRIPTION
This addition allows to configure which days shall be skipped in the
gregorian calendar if the holyday falls onto one.

By default this is saturday and sunday but one can now also only define
one or multiple days.

Thanks to Sarel van der Walt for the input for that

This PR fixes #30 