### PR TITLE
Small typo fix with german "Heiligabend"

### DIFF
--- a/share/DE.xml
+++ b/share/DE.xml
@@ -23,7 +23,7 @@
     <relative day="25" month="12" free="false" relation="last sunday -2 weeks">2. Advent</relative>
     <relative day="25" month="12" free="false" relation="last sunday -1 weeks">3. Advent</relative>
     <relative day="25" month="12" free="false" relation="last sunday">4. Advent</relative>
-    <date day="24" month="12" free="false">Heilig Abend</date>
+    <date day="24" month="12" free="false">Heiligabend</date>
     <date day="25" month="12" free="true">1. Weihnachtstag</date>
     <date day="26" month="12" free="true">2. Weihnachtstag</date>
     <date day="31" month="12" free="false">Silvester</date>


### PR DESCRIPTION
Servus! 

Nice library but as i had a curious look into the german holidays, i found a small typo with the christmas eve and corrected it. 

Also see the "Duden", which is an official source for german spelling.

https://www.duden.de/rechtschreibung/Heiligabend

Thanks! 👍🏼