### PR TITLE
Remove obsolete return type

### DIFF
--- a/src/IteratorItem/Easter.php
+++ b/src/IteratorItem/Easter.php
@@ -63,10 +63,6 @@ class Easter implements HolidayIteratorItemInterface
 		$easter = $this->getEaster($year);
 		$day = $this->getOffsetDay($easter, $this->offset);
 
-		if (false === $day) {
-			return false;
-		}
-
         $comparator = new DateIntervalComparator();
         return 0 > $comparator->compare($day->diff($date), new DateInterval('P1D'));
     }
@@ -91,7 +87,7 @@ class Easter implements HolidayIteratorItemInterface
 
 	/**
 	 * @param DateTime|DateTimeImmutable $date
-	 * @return DateTime|DateTimeImmutable|false
+	 * @return DateTime|DateTimeImmutable
 	 */
 	private function getOffsetDay($date, int $offset)
 	{


### PR DESCRIPTION
The `add` and `sub` methods of `DateTime[Immutable]` always return an object and never `false` so we do not need to declare `false` as return type