### PR TITLE
Standardize ISO method name in README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,13 @@ by adding the [ISO 639-1 language-code](https://en.wikipedia.org/wiki/ISO_3166-2
 
 ```php
 // Get the holidays for mainland france
-$iterator = $factory->createIteratorFromIso3166('FR');
+$iterator = $factory->createIteratorFromISO3166('FR');
 
 // Get the holidays for the french overseas-department La Reunion
-$iterator = $factory->createIteratorFromIso3166('FR-RE');
+$iterator = $factory->createIteratorFromISO3166('FR-RE');
 
 // Get the dutch holidays for belgium
-$iterator = $factory->createIteratorFromIso3166('fr_BE');
+$iterator = $factory->createIteratorFromISO3166('fr_BE');
 ```
 
 ## Available Countries

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,13 +43,13 @@ by adding the [ISO 639-1 language-code](https://en.wikipedia.org/wiki/ISO_3166-2
 
 ```php
 // Get the holidays for mainland france
-$iterator = $factory->createIteratorFromIso3166('FR');
+$iterator = $factory->createIteratorFromISO3166('FR');
 
 // Get the holidays for the french overseas-department La Reunion
-$iterator = $factory->createIteratorFromIso3166('FR-RE');
+$iterator = $factory->createIteratorFromISO3166('FR-RE');
 
 // Get the dutch holidays for belgium
-$iterator = $factory->createIteratorFromIso3166('fr_BE');
+$iterator = $factory->createIteratorFromISO3166('fr_BE');
 ```
 
 ## Available Countries


### PR DESCRIPTION
Updated the method name from `createIteratorFromIso3166` to `createIteratorFromISO3166` in `README.md` and `docs/index.md`. This standardizes the capitalization in the method name, ensuring consistency throughout the documentation.

https://github.com/heiglandreas/holidayChecker/blob/f7fbe36f635327277548a094524183a453eb4f0a/src/HolidayIteratorFactory.php#L77-L84