### PR TITLE
Update tests so they run with any PHPUnit version

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -59,6 +59,8 @@ jobs:
           coverage: xdebug
       - name: prepare
         run: composer update
+      - name: Install PHPUnit
+        run: composer require --dev phpunit/phpunit
       - name: test
         run: composer test
 #  upload-xsd-file:
@@ -105,10 +107,12 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.0"
+          php-version: "8.3"
           coverage: xdebug
       - name: Install
         run: composer update
+      - name: Install PHPUnit
+        run: composer require --dev phpunit/phpunit
       - name: run testsuite
         run: composer test-coverage
       - name: upload to coveralls

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,6 @@
     "org_heigl/dateintervalcomparator": "^1.0"
   },
   "require-dev": {
-    "mockery/mockery": "^1.0",
-    "phpunit/phpunit": "^8.0 || ^9.0",
     "slevomat/coding-standard": "^6.4 || ^7.0 || ^8.0",
     "squizlabs/php_codesniffer": "^3.0"
   },
@@ -60,6 +58,6 @@
     "cs-fix": "phpcbf",
     "test": "phpunit --colors=always",
     "lintxml" : "for i in `ls share/*.xml` ; do xmllint --xinclude --noout --schema share/holidays.xsd $i; if [ ! $? -eq 0 ] ; then exit 1; fi; done || exit 1",
-    "test-coverage": "phpunit --colors=always --coverage-clover clover.xml"
+    "test-coverage": "phpunit -c phpunit-coverage.xml.dist --colors=always --coverage-clover clover.xml"
   }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -16,7 +16,6 @@ parameters:
 
     paths:
         - src/
-        - tests/
 
     reportMaybesInMethodSignatures: false
     reportMaybesInPropertyPhpDocTypes: false

--- a/phpunit-coverage.xml.dist
+++ b/phpunit-coverage.xml.dist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.0/phpunit.xsd"
+		 bootstrap="vendor/autoload.php"
+		 beStrictAboutOutputDuringTests="true"
+		 cacheDirectory=".phpunit.cache"
+		 requireCoverageMetadata="false"
+		 beStrictAboutCoverageMetadata="false"
+>
+  <testsuite name="Holidaychecker-TestSuite">
+    <directory suffix="Test.php">tests</directory>
+  </testsuite>
+  <source>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </source>
+</phpunit>

--- a/tests/CalendarDayTest.php
+++ b/tests/CalendarDayTest.php
@@ -37,35 +37,36 @@ use DateTimeInterface;
 use IntlCalendar;
 use Org_Heigl\Holidaychecker\Calendar;
 use Org_Heigl\Holidaychecker\CalendarDay;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class CalendarDayTest extends TestCase
 {
-	/**
-	 * @return void
-	 */
-    public function testConstructorCalendar()
+	public function testConstructorCalendar(): void
     {
-        $calendar = $this->getMockBuilder(IntlCalendar::class)->disableOriginalConstructor()->getMock();
-        $calendar->expects($this->exactly(4))->method('set');
+        $calendar = IntlCalendar::createInstance();
 
         $class = new CalendarDay(2, 3, $calendar);
 
         self::assertInstanceOf(CalendarDay::class, $class);
-    }
+		self::assertSame(2, $calendar->get(IntlCalendar::FIELD_DAY_OF_MONTH));
+		self::assertSame(2, $calendar->get(IntlCalendar::FIELD_MONTH));
+		self::assertSame(12, $calendar->get(IntlCalendar::FIELD_HOUR_OF_DAY));
+		self::assertSame(0, $calendar->get(IntlCalendar::FIELD_MINUTE));
+		self::assertSame(0, $calendar->get(IntlCalendar::FIELD_SECOND));
+		self::assertSame(0, $calendar->get(IntlCalendar::FIELD_MILLISECOND));
+	}
 
-    /**
-	 * @dataProvider theSameDayWithoutCheckingYearProvider
-	 * @param int $day
-	 * @param int $month
-	 * @param int|null $year
-	 * @param string $calendar
-	 * @param DateTimeImmutable $compare
-	 * @param bool $result
-	 * @return void
-	 */
-    public function testIsSameDay($day, $month, $year, $calendar, $compare, $result)
-    {
+	/** @dataProvider theSameDayWithoutCheckingYearProvider */
+	#[DataProvider('theSameDayWithoutCheckingYearProvider')]
+    public function testIsSameDay(
+		int $day,
+		int $month,
+		?int $year,
+		string $calendar,
+		DateTimeImmutable $compare,
+		bool $result
+	): void {
         $cal = IntlCalendar::createInstance(null, '@calendar=' . $calendar);
 
         $class = new CalendarDay($day, $month, $cal);
@@ -86,8 +87,8 @@ class CalendarDayTest extends TestCase
 	 *     bool
 	 * }[]
 	 */
-    public static function theSameDayWithoutCheckingYearProvider()
-    {
+    public static function theSameDayWithoutCheckingYearProvider(): array
+	{
         return [
             'Month doesnt match' => [1, 1, null, Calendar::GREGORIAN, new DateTimeImmutable('1.2.2000'), false],
             'Day doesnt match'   => [1, 1, null, Calendar::GREGORIAN, new DateTimeImmutable('2.1.2000'), false],
@@ -100,16 +101,15 @@ class CalendarDayTest extends TestCase
         ];
     }
 
-    /**
-	 * @dataProvider provideTheWeekdayIsReturnedCorrectly
-	 * @param int $day
-	 * @param int $month
-	 * @param int $year
-	 * @param string $calendar
-	 * @param bool $result
-	 * @return void*/
-    public function testThatTheWeekdayIsReturnedCorrectly($day, $month, $year, $calendar, $result)
-    {
+	/** @dataProvider provideTheWeekdayIsReturnedCorrectly */
+	#[DataProvider('provideTheWeekdayIsReturnedCorrectly')]
+    public function testThatTheWeekdayIsReturnedCorrectly(
+		int $day,
+		int $month,
+		int $year,
+		string $calendar,
+		int $result
+	): void {
         $cal = IntlCalendar::createInstance(null, '@calendar=' . $calendar);
         $class = new CalendarDay($day, $month, $cal);
 
@@ -157,7 +157,8 @@ class CalendarDayTest extends TestCase
         ];
     }
 
-    /** @dataProvider followUpIsCalculatedCorrectlyProvider */
+	/** @dataProvider followUpIsCalculatedCorrectlyProvider */
+    #[DataProvider('followUpIsCalculatedCorrectlyProvider')]
     public function testThatFollowUpIsCalculatedCorrectly(
         int $day,
         int $month,
@@ -181,7 +182,7 @@ class CalendarDayTest extends TestCase
 	 * }[]
 	 */
 
-	public function followUpIsCalculatedCorrectlyProvider(): array
+	public static function followUpIsCalculatedCorrectlyProvider(): array
     {
         return [
             [25, 11, new DateTimeImmutable('2020-11-29T12:00:00Z'), 'sunday'],

--- a/tests/GregorianWeekdayTest.php
+++ b/tests/GregorianWeekdayTest.php
@@ -13,15 +13,15 @@ namespace Org_Heigl\HolidaycheckerTest;
 use DateTimeImmutable;
 use IntlCalendar;
 use Org_Heigl\Holidaychecker\GregorianWeekday;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use UnexpectedValueException;
 
 class GregorianWeekdayTest extends TestCase
 {
-	/**
-	 * @dataProvider workdayProvider
-	 */
+	/** @dataProvider workdayProvider */
+	#[DataProvider('workdayProvider')]
 	public function testFromStringWorksAsExpectedForKnownWeekdays(string $string): void
 	{
 		$expected = GregorianWeekday::fromString($string);
@@ -33,7 +33,7 @@ class GregorianWeekdayTest extends TestCase
 	/**
 	 * @return array{string}[]
 	 */
-	public function workdayProvider(): array
+	public static function workdayProvider(): array
 	{
 		return [
 			['monday'],
@@ -49,7 +49,7 @@ class GregorianWeekdayTest extends TestCase
 	public function testFromStringThrowsWithUnknownString(): void
 	{
 		$this->expectException(RuntimeException::class);
-		$this->expectErrorMessage('Weekday "wtf" is not known');
+		$this->expectExceptionMessage('Weekday "wtf" is not known');
 		GregorianWeekday::fromString('wtf');
 	}
 

--- a/tests/HolidaycheckerTest.php
+++ b/tests/HolidaycheckerTest.php
@@ -36,43 +36,37 @@ use DateInterval;
 use DatePeriod;
 use DateTime;
 use DateTimeImmutable;
+use Org_Heigl\Holidaychecker\Holiday;
 use Org_Heigl\Holidaychecker\Holidaychecker;
+use Org_Heigl\Holidaychecker\HolidayIterator;
 use Org_Heigl\Holidaychecker\HolidayIteratorFactory;
+use Org_Heigl\Holidaychecker\IteratorItem\Date;
+use Org_Heigl\Holidaychecker\IteratorItem\Easter;
+use Org_Heigl\Holidaychecker\IteratorItem\Relative;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use function date;
 use function microtime;
 use function sprintf;
 
+#[CoversClass(HolidayIteratorFactory::class)]
+#[CoversClass(Holidaychecker::class)]
+#[CoversClass(Holiday::class)]
+#[CoversClass(HolidayIterator::class)]
+#[CoversClass(Date::class)]
+#[CoversClass(Easter::class)]
+#[CoversClass(Relative::class)]
 class HolidaycheckerTest extends TestCase
 {
-    /**
-     * @dataProvider integrationProvider
-     * @covers \Org_Heigl\Holidaychecker\HolidayIteratorFactory::createIteratorFromXmlFile
-     * @covers \Org_Heigl\Holidaychecker\Holidaychecker::__construct
-     * @covers \Org_Heigl\Holidaychecker\Holidaychecker::check
-     * @covers \Org_Heigl\Holidaychecker\Holiday::isHoliday
-     * @covers \Org_Heigl\Holidaychecker\Holiday::isNamed
-     * @covers \Org_Heigl\Holidaychecker\Holiday::getName
-     * @covers \Org_Heigl\Holidaychecker\Holiday::__construct
-     * @covers \Org_Heigl\Holidaychecker\HolidayIterator::append
-     * @covers \Org_Heigl\Holidaychecker\HolidayIteratorFactory::getElement
-     * @covers \Org_Heigl\Holidaychecker\HolidayIteratorFactory::getFree
-     * @covers \Org_Heigl\Holidaychecker\IteratorItem\Date::__construct
-     * @covers \Org_Heigl\Holidaychecker\IteratorItem\Date::dateMatches
-     * @covers \Org_Heigl\Holidaychecker\IteratorItem\Easter::__construct
-     * @covers \Org_Heigl\Holidaychecker\IteratorItem\Easter::dateMatches
-     * @covers \Org_Heigl\Holidaychecker\IteratorItem\Easter::getEaster
-     * @covers \Org_Heigl\Holidaychecker\IteratorItem\Easter::getName
-     * @covers \Org_Heigl\Holidaychecker\IteratorItem\Easter::isHoliday
-     * @covers \Org_Heigl\Holidaychecker\IteratorItem\Relative::__construct
-	 * @param DateTime $date
-	 * @param bool $holiday
-	 * @param bool $named
-	 * @param string $name
-	 * @return void
-     */
-    public function testIntegration($date, $holiday, $named, $name)
-    {
+	/** @dataProvider integrationProvider */
+	#[DataProvider('integrationProvider')]
+    public function testIntegration(
+		DateTime $date,
+		bool $holiday,
+		bool $named,
+		string $name
+	): void {
         $factory = new HolidayIteratorFactory();
         $iterator = $factory->createIteratorFromXmlFile(__DIR__ . '/../share/DE-HE.xml');
         $checker = new Holidaychecker($iterator);
@@ -91,7 +85,7 @@ class HolidaycheckerTest extends TestCase
      *     string
      * }[]
      */
-    public function integrationProvider()
+    public static function integrationProvider()
     {
         return [
             [new DateTime('2017-04-16'), false, true, 'Ostersonntag'],
@@ -99,33 +93,7 @@ class HolidaycheckerTest extends TestCase
         ];
     }
 
-    /**
-     * @covers \Org_Heigl\Holidaychecker\HolidayIteratorFactory::createIteratorFromXmlFile
-     * @covers \Org_Heigl\Holidaychecker\Holidaychecker::__construct
-     * @covers \Org_Heigl\Holidaychecker\Holidaychecker::check
-     * @covers \Org_Heigl\Holidaychecker\Holiday::isHoliday
-     * @covers \Org_Heigl\Holidaychecker\Holiday::isNamed
-     * @covers \Org_Heigl\Holidaychecker\Holiday::getName
-     * @covers \Org_Heigl\Holidaychecker\Holiday::__construct
-     * @covers \Org_Heigl\Holidaychecker\HolidayIterator::append
-     * @covers \Org_Heigl\Holidaychecker\HolidayIteratorFactory::getElement
-     * @covers \Org_Heigl\Holidaychecker\HolidayIteratorFactory::getFree
-     * @covers \Org_Heigl\Holidaychecker\IteratorItem\Date::__construct
-     * @covers \Org_Heigl\Holidaychecker\IteratorItem\Date::dateMatches
-     * @covers \Org_Heigl\Holidaychecker\IteratorItem\Easter::__construct
-     * @covers \Org_Heigl\Holidaychecker\IteratorItem\Easter::dateMatches
-     * @covers \Org_Heigl\Holidaychecker\IteratorItem\Easter::getEaster
-     * @covers \Org_Heigl\Holidaychecker\IteratorItem\Easter::getName
-     * @covers \Org_Heigl\Holidaychecker\IteratorItem\Easter::isHoliday
-     * @covers \Org_Heigl\Holidaychecker\IteratorItem\Relative::__construct
-     * @covers \Org_Heigl\Holidaychecker\IteratorItem\Date::getName
-     * @covers \Org_Heigl\Holidaychecker\IteratorItem\Date::isHoliday
-     * @covers \Org_Heigl\Holidaychecker\IteratorItem\Relative::dateMatches
-     * @covers \Org_Heigl\Holidaychecker\IteratorItem\Relative::getName
-     * @covers \Org_Heigl\Holidaychecker\IteratorItem\Relative::isHoliday
-	 * @return void
-     */
-    public function testSpeed()
+    public function testSpeed(): void
     {
         $factory = new HolidayIteratorFactory();
         $iterator = $factory->createIteratorFromXmlFile(__DIR__ . '/../share/DE-HE.xml');
@@ -153,11 +121,9 @@ class HolidaycheckerTest extends TestCase
         $this->assertTrue($duration < 0.2);
     }
 
-    /**
-     * @dataProvider datesProvider
-	 * @return void
-     */
-    public function testDates(string $code, DateTimeImmutable $date, string $dayname)
+	/** @dataProvider datesProvider */
+	#[DataProvider('datesProvider')]
+    public function testDates(string $code, DateTimeImmutable $date, string $dayname): void
     {
         $factory = new HolidayIteratorFactory();
         $iterator = $factory->createIteratorFromXmlFile(__DIR__ . '/../share/' . $code . '.xml');
@@ -174,7 +140,7 @@ class HolidaycheckerTest extends TestCase
 	 *     string
 	 * }[]
 	 */
-    public function datesProvider()
+    public static function datesProvider()
     {
         return [
             ['AF', new DateTimeImmutable('2022-10-08'), 'Mawlid'],

--- a/tests/Integration/BahrainTest.php
+++ b/tests/Integration/BahrainTest.php
@@ -14,16 +14,14 @@ use DateTimeImmutable;
 use DateTimeZone;
 use Org_Heigl\Holidaychecker\Holidaychecker;
 use Org_Heigl\Holidaychecker\HolidayIteratorFactory;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class BahrainTest extends TestCase
 {
-	/**
-	 * @dataProvider dayProvider
-	 * @param DateTimeImmutable $day
-	 * @return void
-	 */
-	public function testBahrainHolidays($day)
+	/** @dataProvider dayProvider */
+	#[DataProvider('dayProvider')]
+	public function testBahrainHolidays(DateTimeImmutable $day): void
 	{
 		$factory = new HolidayIteratorFactory();
 		$iterator = $factory->createIteratorFromISO3166('BH');
@@ -35,7 +33,7 @@ class BahrainTest extends TestCase
 	/**
 	 * @return array{DateTimeImmutable}[]
 	 */
-	public function dayProvider(): array
+	public static function dayProvider(): array
 	{
 		return [
 			'New Year' => [new DateTimeImmutable('2015-01-01 12:00:00', new DateTimeZone('Asia/Bahrain'))],

--- a/tests/IteratorItem/DateFollowUpTest.php
+++ b/tests/IteratorItem/DateFollowUpTest.php
@@ -36,37 +36,28 @@ use DateTimeImmutable;
 use Org_Heigl\Holidaychecker\Calendar;
 use Org_Heigl\Holidaychecker\CalendarDayFactory;
 use Org_Heigl\Holidaychecker\IteratorItem\DateFollowUp;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
+#[CoversClass(DateFollowUp::class)]
 class DateFollowUpTest extends TestCase
 {
     /**
-     * @dataProvider dateProvider
-     * @covers \Org_Heigl\Holidaychecker\IteratorItem\DateFollowUp::getName
-     * @covers \Org_Heigl\Holidaychecker\IteratorItem\DateFollowUp::isHoliday
-     * @covers \Org_Heigl\Holidaychecker\IteratorItem\DateFollowUp::__construct
-     * @covers \Org_Heigl\Holidaychecker\IteratorItem\DateFollowUp::dateMatches
-     * @covers \Org_Heigl\Holidaychecker\IteratorItem\DateFollowUp::replacedDays
-	 * @param DateTimeImmutable $dateTime
-	 * @param int $day
-	 * @param int $month
-	 * @param string $followup
-	 * @param array<"sunday"|"monday"|"tuesday"|"wednesday"|"thursday"|"friday"|"saturday"> $replaced
-	 * @param bool $result
-	 * @param string $name
-	 * @param bool $isHoliday
-	 * @return void
+	 * @dataProvider dateProvider
+     * @param array<"sunday"|"monday"|"tuesday"|"wednesday"|"thursday"|"friday"|"saturday"> $replaced
 	 */
+	#[DataProvider('dateProvider')]
     public function testThatDateFollowupTestWorks(
-        $dateTime,
-        $day,
-        $month,
-        $followup,
-        $replaced,
-        $result,
-        $name,
-        $isHoliday
-    ) {
+        DateTimeImmutable $dateTime,
+        int $day,
+        int $month,
+        string $followup,
+        array $replaced,
+        bool $result,
+        string $name,
+        bool $isHoliday
+    ): void {
         $calendarDate = CalendarDayFactory::createCalendarDay($day, $month, Calendar::GREGORIAN);
 
         $followUp = new DateFollowUp($name, $isHoliday, $calendarDate, $followup, $replaced);
@@ -87,7 +78,7 @@ class DateFollowUpTest extends TestCase
      *     bool
      * }[]
      */
-    public function dateProvider()
+    public static function dateProvider()
     {
         return [
             [new DateTimeImmutable('2018-03-01 12:00:00+00:00'), 25, 2, 'thursday', [], true, 'test', true],

--- a/tests/IteratorItem/DateTest.php
+++ b/tests/IteratorItem/DateTest.php
@@ -36,26 +36,24 @@ use DateTime;
 use Org_Heigl\Holidaychecker\Calendar;
 use Org_Heigl\Holidaychecker\CalendarDayFactory;
 use Org_Heigl\Holidaychecker\IteratorItem\Date;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
+#[CoversClass(Date::class)]
 class DateTest extends TestCase
 {
-    /**
-     * @dataProvider dateProvider
-     * @covers \Org_Heigl\Holidaychecker\IteratorItem\Date::getName
-     * @covers \Org_Heigl\Holidaychecker\IteratorItem\Date::isHoliday
-     * @covers \Org_Heigl\Holidaychecker\IteratorItem\Date::__construct
-     * @covers \Org_Heigl\Holidaychecker\IteratorItem\Date::dateMatches
-	 * @param DateTime $dateTime
-	 * @param int $day
-	 * @param int $month
-	 * @param int|null $year
-	 * @param bool $result
-	 * @param string $name
-	 * @param bool $isHoliday
-	 * @return void*/
-    public function testThatDateTestWorks($dateTime, $day, $month, $year, $result, $name, $isHoliday)
-    {
+	/** @dataProvider dateProvider */
+	#[DataProvider('dateProvider')]
+    public function testThatDateTestWorks(
+		DateTime $dateTime,
+		int $day,
+		int $month,
+		?int $year,
+		bool $result,
+		string $name,
+		bool $isHoliday
+	): void {
         $calendarDate = CalendarDayFactory::createCalendarDay($day, $month, Calendar::GREGORIAN);
         if ($year) {
             $calendarDate->setYear($year);
@@ -77,7 +75,7 @@ class DateTest extends TestCase
      *     bool
      * }[]
      */
-	public function dateProvider()
+	public static function dateProvider()
     {
         return [
             [new DateTime('2017-12-24 12:00:00+00:00'), 24, 12, null, true, 'test', true],

--- a/tests/IteratorItem/EasterOrthodoxTest.php
+++ b/tests/IteratorItem/EasterOrthodoxTest.php
@@ -34,27 +34,22 @@ namespace Org_Heigl\HolidaycheckerTest\IteratorItem;
 
 use DateTime;
 use Org_Heigl\Holidaychecker\IteratorItem\EasterOrthodox;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
+#[CoversClass(EasterOrthodox::class)]
 class EasterOrthodoxTest extends TestCase
 {
-    /**
-     * @dataProvider easterProvider
-     * @covers \Org_Heigl\Holidaychecker\IteratorItem\EasterOrthodox::getName
-     * @covers \Org_Heigl\Holidaychecker\IteratorItem\EasterOrthodox::isHoliday
-     * @covers \Org_Heigl\Holidaychecker\IteratorItem\EasterOrthodox::__construct
-     * @covers \Org_Heigl\Holidaychecker\IteratorItem\EasterOrthodox::dateMatches
-     * @covers \Org_Heigl\Holidaychecker\IteratorItem\EasterOrthodox::getOrthodoxEaster
-     * @covers \Org_Heigl\Holidaychecker\IteratorItem\EasterOrthodox::getEaster
-	 * @param DateTime $dateTime
-	 * @param int $offset
-	 * @param bool $result
-	 * @param string $name
-	 * @param bool $isHoliday
-	 * @return void
-	 */
-    public function testThatEasterIsIdentifiedCorrectly($dateTime, $offset, $result, $name, $isHoliday)
-    {
+	/** @dataProvider easterProvider */
+	#[DataProvider('easterProvider')]
+    public function testThatEasterIsIdentifiedCorrectly(
+		DateTime $dateTime,
+		int $offset,
+		bool $result,
+		string $name,
+		bool $isHoliday
+	): void {
         $easter = new EasterOrthodox($name, $isHoliday, $offset);
         $this->assertEquals($result, $easter->dateMatches($dateTime));
         $this->assertEquals($name, $easter->getName());
@@ -70,7 +65,7 @@ class EasterOrthodoxTest extends TestCase
 	 *     bool
 	 * }[]
 	 */
-	public function easterProvider()
+	public static function easterProvider()
     {
         return [
             [new DateTime('2016-04-20 12:00:00+00:00'), -10, true, 'test', true],

--- a/tests/IteratorItem/EasterTest.php
+++ b/tests/IteratorItem/EasterTest.php
@@ -34,26 +34,22 @@ namespace Org_Heigl\HolidaycheckerTest\IteratorItem;
 
 use DateTime;
 use Org_Heigl\Holidaychecker\IteratorItem\Easter;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
+#[CoversClass(Easter::class)]
 class EasterTest extends TestCase
 {
-    /**
-     * @dataProvider easterProvider
-     * @covers \Org_Heigl\Holidaychecker\IteratorItem\Easter::getName
-     * @covers \Org_Heigl\Holidaychecker\IteratorItem\Easter::isHoliday
-     * @covers \Org_Heigl\Holidaychecker\IteratorItem\Easter::__construct
-     * @covers \Org_Heigl\Holidaychecker\IteratorItem\Easter::dateMatches
-     * @covers \Org_Heigl\Holidaychecker\IteratorItem\Easter::getEaster
-	 * @param DateTime $dateTime
-	 * @param int $offset
-	 * @param bool $result
-	 * @param string $name
-	 * @param bool $isHoliday
-	 * @return void
-	 */
-    public function testThatEasterIsIdentifiedCorrectly($dateTime, $offset, $result, $name, $isHoliday)
-    {
+	/** @dataProvider easterProvider */
+	#[DataProvider('easterProvider')]
+    public function testThatEasterIsIdentifiedCorrectly(
+		DateTime $dateTime,
+		int $offset,
+		bool $result,
+		string $name,
+		bool $isHoliday
+	): void {
         $easter = new Easter($name, $isHoliday, $offset);
         $this->assertEquals($result, $easter->dateMatches($dateTime));
         $this->assertEquals($name, $easter->getName());
@@ -69,7 +65,7 @@ class EasterTest extends TestCase
      *     bool
      * }[]
      */
-    public function easterProvider()
+    public static function easterProvider()
     {
         return [
             [new DateTime('2017-04-06 12:00:00+00:00'), -10, true, 'test', true],

--- a/tests/IteratorItem/RelativeTest.php
+++ b/tests/IteratorItem/RelativeTest.php
@@ -34,27 +34,24 @@ namespace Org_Heigl\HolidaycheckerTest\IteratorItem;
 
 use DateTime;
 use Org_Heigl\Holidaychecker\IteratorItem\Relative;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
+#[CoversClass(Relative::class)]
 class RelativeTest extends TestCase
 {
-    /**
-     * @dataProvider dateProvider
-     * @covers \Org_Heigl\Holidaychecker\IteratorItem\Relative::getName
-     * @covers \Org_Heigl\Holidaychecker\IteratorItem\Relative::isHoliday
-     * @covers \Org_Heigl\Holidaychecker\IteratorItem\Relative::__construct
-     * @covers \Org_Heigl\Holidaychecker\IteratorItem\Relative::dateMatches
-	 * @param DateTime $dateTime
-	 * @param int $day
-	 * @param int $month
-	 * @param string $relation
-	 * @param bool $result
-	 * @param string $name
-	 * @param bool $isHoliday
-	 * @return void
-     */
-    public function testThatDateTestWorks($dateTime, $day, $month, $relation, $result, $name, $isHoliday)
-    {
+	/** @dataProvider dateProvider */
+	#[DataProvider('dateProvider')]
+    public function testThatDateTestWorks(
+		DateTime $dateTime,
+		int $day,
+		int $month,
+		string $relation,
+		bool $result,
+		string $name,
+		bool $isHoliday
+	): void {
         $easter = new Relative($name, $isHoliday, $day, $month, $relation);
         $this->assertEquals($result, $easter->dateMatches($dateTime));
         $this->assertEquals($name, $easter->getName());
@@ -72,7 +69,7 @@ class RelativeTest extends TestCase
      *     bool
      * }[]
      */
-    public function dateProvider()
+    public static function dateProvider()
     {
         return [
             [new DateTime('2017-12-03 12:00:00+00:00'), 25, 12, 'last sunday -3 weeks', true, 'test', true],

--- a/tests/ObservanceDecoratorTest.php
+++ b/tests/ObservanceDecoratorTest.php
@@ -13,13 +13,13 @@ namespace Org_Heigl\HolidaycheckerTest;
 use DateTimeImmutable;
 use Org_Heigl\Holidaychecker\HolidayIteratorItemInterface;
 use Org_Heigl\Holidaychecker\ObservanceDecorator;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class ObservanceDecoratorTest extends TestCase
 {
-    /**
-     * @dataProvider provider
-     */
+	/** @dataProvider provider */
+	#[DataProvider('provider')]
     public function testDecoratorWorksAsExpected(?int $firstObservance, ?int $lastObservance, int $testYear, bool $expectedResult): void
     {
 		$decorated = $this->getMockBuilder(HolidayIteratorItemInterface::class)->getMock();
@@ -36,7 +36,7 @@ class ObservanceDecoratorTest extends TestCase
     /**
      * @return array<array{(int|null), (int|null), int, bool}>
      */
-    public function provider(): array
+    public static function provider(): array
     {
         return [
             [null, null, 2022, true],


### PR DESCRIPTION
As we want to run tests with PHP from 7.3 through 8.5 we need to adjust the tests a bit so that they can be ran with all different versions of PHPUnit