### PR TITLE
Increase supply-chain security

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     interval: daily
     time: "04:00"
   cooldown:
-      default-days: 5
+      default-days: 7
   open-pull-requests-limit: 10
 - package-ecosystem: bundler
   directory: "/docs"
@@ -14,9 +14,11 @@ updates:
     interval: daily
     time: "04:00"
   open-pull-requests-limit: 10
+  cooldown:
+    default-days: 7
 - package-ecosystem: github-actions
   directory: '/'
   schedule:
       interval: weekly
   cooldown:
-      default-days: 5
+      default-days: 7

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -4,15 +4,22 @@ on:
   push:
     branches:
       - 'main'
+permissions: {}
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
 jobs:
   check:
+    name: Check Codestyle
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # 7.0.1
+        with:
+          persist-credentials: false
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: "8.4"
           tools: phive
@@ -26,13 +33,16 @@ jobs:
       - name: check
         run: ./tools/phpcs/vendor/bin/phpcs
   xml-lint:
+    name: Lint XML-Files
     runs-on: ubuntu-latest
     continue-on-error: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # 7.0.1
+        with:
+          persist-credentials: false
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: "8.4"
       - name: Install xmllint
@@ -56,9 +66,11 @@ jobs:
     name: "PHP ${{ matrix.php-versions }}-icu${{ matrix.icu-versions }} # Test on ${{ matrix.operating-system }}"
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # 7.0.1
+        with:
+          persist-credentials: false
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: ${{ matrix.php-versions }}
           extensions: sodium, intl-${{matrix.icu-versions}}
@@ -87,14 +99,17 @@ jobs:
 #        run: |
 #          curl --ftp-create-dirs -T share/holidays.xsd -u "$FTP_USER":"$FTP_PASS" ftp://ftp.heigl.org:21/holidays.xsd
   analyze:
+    name: Run static analysis
     needs: test
     runs-on: ubuntu-latest
     continue-on-error: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # 7.0.1
+        with:
+          persist-credentials: false
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: "8.4"
       - name: Download phpstan
@@ -105,14 +120,17 @@ jobs:
       - name: analyze
         run: ./vendor/bin/phpstan
   coverage:
+    name: Create code-coverage
     needs: test
     runs-on: ubuntu-latest
     continue-on-error: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # 7.0.1
+        with:
+          persist-credentials: false
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: "8.4"
           coverage: xdebug
@@ -129,7 +147,7 @@ jobs:
           composer global require php-coveralls/php-coveralls
           php-coveralls --coverage_clover=clover.xml -v
       - name: upload to codecov
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # 7.0.0
         with:
           #token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
           files: ./clover.xml # optional

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -55,15 +55,29 @@ jobs:
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
-        # operating-system: [ubuntu-latest, windows-latest, macos-latest]
-        php-versions: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
-        icu-versions: ['74.1', '73.2', '73.1', '71.1', '69.1', '67.1']
+        # All currently supported PHP-Versions are tested against all ICU-versions that were active since release of
+        # the oldest PHP-Version
+        php-versions: ['8.2', '8.3', '8.4', '8.5']
+        icu-versions: ['74.1', '74.2', '75.1', '76.1', '77.1', '78.1', '78.2', '78.3']
         experimental: [false]
         include:
+          # The nightly version is only tested against the latest ICU-version
           - php-versions: '8.6'
-            icu-versions: '74.1'
+            icu-versions: '78.3'
             experimental: true
-    name: "PHP ${{ matrix.php-versions }}-icu${{ matrix.icu-versions }} # Test on ${{ matrix.operating-system }}"
+          - php-versions: '7.3' # EOL 06.12.2021, last release: 7.3.33 on 18.11.2021
+            icu-versions: '70.1' # release: 28.10.2021
+            experimental: false
+          - php-versions: '7.4' # EOL 28.11.2022, last release: 7.4.33 on 03.11.2022
+            icu-versions: '72.1' # release: 18.10.2022
+            experimental: false
+          - php-versions: '8.0' # EOL 26.11.2023, last release: 8.0.30 on 03.08.2023
+            icu-versions: '73.2' # release: 13.06.2023
+            experimental: false
+          - php-versions: '8.1' # EOL 31.12.2025, last release: 8.1.34 on 18.12.2025
+            icu-versions: '78.1' # release: 30.10.2023
+            experimental: false
+    name: "Test on PHP ${{ matrix.php-versions }} with icu${{ matrix.icu-versions }}"
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # 7.0.1

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -2,7 +2,7 @@
 <ruleset name="HolidayChecker">
 	<description>The coding standard for HolidayChecker</description>
 
-	<config name="installed_paths" value="vendor/slevomat/coding-standard"/>
+	<config name="installed_paths" value="tools/phpcs/vendor/slevomat/coding-standard"/>
 	<autoload>vendor/autoload.php</autoload>
 
 	<arg name="basepath" value="."/>
@@ -200,7 +200,7 @@
 	<!-- Require there be no space between increment/decrement operator and its operand -->
 	<rule ref="Generic.WhiteSpace.IncrementDecrementSpacing"/>
 	<!-- Require space after language constructs -->
-	<rule ref="Squiz.WhiteSpace.LanguageConstructSpacing"/>
+	<rule ref="Generic.WhiteSpace.LanguageConstructSpacing"/>
 	<!-- Require space around logical operators -->
 	<rule ref="Squiz.WhiteSpace.LogicalOperatorSpacing"/>
 	<!-- Forbid spaces around `->` operator -->


### PR DESCRIPTION
This updates some information via zizmor to increase the supply-chain
security. Mainly it ties the used actions to explicit ones so that using
infected ones will become much harder. It also removes some
automatically too broad access rights